### PR TITLE
libsupervisionary: removed defunct Rust feature selection, now stable

### DIFF
--- a/libsupervisionary/src/lib.rs
+++ b/libsupervisionary/src/lib.rs
@@ -19,7 +19,5 @@
 //! [Nick Spinale]: https://nickspinale.com
 //! [Arm Research]: http://www.arm.com/research
 
-#![feature(const_fn_trait_bound)]
-
 pub mod build;
 pub mod raw;


### PR DESCRIPTION
Signed-off-by: Dominic Mulligan <dominic.p.mulligan@gmail.com>