### PR TITLE
driver: fixed visibility of runtime_state module to get driver building

### DIFF
--- a/wasmi-bindings/src/lib.rs
+++ b/wasmi-bindings/src/lib.rs
@@ -20,7 +20,7 @@
 //! [Nick Spinale]: https://nickspinale.com
 //! [Arm Research]: http://www.arm.com/research
 
-mod runtime_state;
+pub mod runtime_state;
 mod runtime_trap;
 mod system_call_numbers;
 mod system_interface_types;


### PR DESCRIPTION
Signed-off-by: Dominic Mulligan <dominic.p.mulligan@gmail.com>