### PR TITLE
Added start of theorem tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "tests/constant",
     "tests/system",
     "tests/term",
+    "tests/theorem",
     "tests/type",
     "tests/type_former",
     "wasmi-bindings"

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -18,6 +18,12 @@ description  = "Run the driver executable on the term tests."
 env          = { "RUST_LOG" = "info" }
 script       = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/target/release/driver --binary=${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/target/wasm32-unknown-unknown/release/term.wasm"
 
+[tasks.theorem-integration-test]
+description  = "Run the driver executable on the theorem tests."
+env          = { "RUST_LOG" = "info" }
+script       = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/target/release/driver --binary=${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/target/wasm32-unknown-unknown/release/theorem.wasm"
+
+
 [tasks.type-integration-test]
 description  = "Run the driver executable on the type tests."
 env          = { "RUST_LOG" = "info" }
@@ -33,4 +39,4 @@ run_task = { name = ["build"], fork = true }
 
 [tasks.integration-tests]
 workspace = false
-run_task = { name = ["build-indirection", "constant-integration-test", "system-integration-test", "term-integration-test", "type-integration-test", "type-former-integration-test"] }
+dependencies = ["build-indirection", "constant-integration-test", "system-integration-test", "term-integration-test", "theorem-integration-test", "type-integration-test", "type-former-integration-test"]

--- a/driver/Cargo.toml
+++ b/driver/Cargo.toml
@@ -7,7 +7,7 @@ description = "The main driver application, which loads Wasm binaries and execut
 
 [dependencies]
 anyhow           = "1.0.42"
-clap             = "3.0.0-beta.2"
+clap             = "3.2.23"
 env_logger       = "0.9.0"
 log              = "0.4.14"
 system-interface = { path = "../system-interface" }

--- a/kernel/src/handle.rs
+++ b/kernel/src/handle.rs
@@ -97,7 +97,7 @@ where
 }
 
 /// The upper-bound (exclusive) of the preallocated handles.
-pub const PREALLOCATED_HANDLE_UPPER_BOUND: usize = 28;
+pub const PREALLOCATED_HANDLE_UPPER_BOUND: usize = 29;
 
 /// Returns `true` iff the handle is a pre-allocated handle built into the
 /// kernel.
@@ -273,6 +273,13 @@ pub const PREALLOCATED_HANDLE_TERM_FORALL: Handle<tags::Term> = Handle {
 /// existential quantifier constant lifted into a term.
 pub const PREALLOCATED_HANDLE_TERM_EXISTS: Handle<tags::Term> = Handle {
     handle: 27,
+    marker: PhantomData,
+};
+/// A pre-allocated handle used to refer to the truth introduction theorem.
+pub const PREALLOCATED_HANDLE_THEOREM_TRUTH_INTRODUCTION: Handle<
+    tags::Theorem,
+> = Handle {
+    handle: 28,
     marker: PhantomData,
 };
 

--- a/libsupervisionary/src/raw/theorem.rs
+++ b/libsupervisionary/src/raw/theorem.rs
@@ -16,6 +16,16 @@ use crate::raw::{tags, ErrorCode, Handle, Name, RawHandle};
 use std::{convert::TryFrom, marker::PhantomData};
 
 ////////////////////////////////////////////////////////////////////////////////
+// Pre-allocated theorem-related handles.
+////////////////////////////////////////////////////////////////////////////////
+
+/// A pre-allocated handle used to refer to the truth term, the truth constant
+/// lifted into a term.
+pub const PREALLOCATED_HANDLE_THEOREM_TRUTH_INTRODUCTION: Handle<
+    tags::Theorem,
+> = Handle::new(29usize, PhantomData);
+
+////////////////////////////////////////////////////////////////////////////////
 // ABI bindings.
 ////////////////////////////////////////////////////////////////////////////////
 
@@ -104,12 +114,6 @@ extern "C" {
         domain_length: u64,
         range_base: *const RawHandle,
         range_length: u64,
-        result: *mut RawHandle,
-    ) -> i32;
-    /// Raw ABI binding to the `Theorem.Register.Truth.Introduction` function.
-    fn __theorem_register_truth_introduction(
-        hypotheses_base: *const RawHandle,
-        hypotheses_length: u64,
         result: *mut RawHandle,
     ) -> i32;
     /// Raw ABI binding to the `Theorem.Register.Falsity.Elimination` function.
@@ -286,7 +290,7 @@ where
 
 pub fn theorem_register_assumption<T>(
     term_handle: T,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Term>>,
 {
@@ -307,7 +311,7 @@ where
 pub fn theorem_register_weaken<T, U>(
     term_handle: T,
     theorem_handle: U,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Term>>,
     U: Into<Handle<tags::Theorem>>,
@@ -333,7 +337,7 @@ where
 
 pub fn theorem_register_reflexivity<T>(
     term_handle: T,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Term>>,
 {
@@ -453,7 +457,7 @@ where
 
 pub fn theorem_register_beta<T>(
     term_handle: T,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Term>>,
 {
@@ -473,7 +477,7 @@ where
 
 pub fn theorem_register_eta<T>(
     term_handle: T,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Term>>,
 {
@@ -566,38 +570,10 @@ where
     }
 }
 
-pub fn theorem_register_truth_introduction<T>(
-    hypotheses: Vec<T>,
-) -> Result<Handle<tags::Term>, ErrorCode>
-where
-    T: Into<Handle<tags::Term>> + Clone,
-{
-    let mut result: u64 = 0;
-    let hypotheses: Vec<u64> = hypotheses
-        .iter()
-        .cloned()
-        .map(|h| *(h.into()) as u64)
-        .collect();
-
-    let status = unsafe {
-        __theorem_register_truth_introduction(
-            hypotheses.as_ptr(),
-            hypotheses.len() as u64,
-            &mut result as *mut u64,
-        )
-    };
-
-    if status == 0 {
-        Ok(Handle::new(result as usize, PhantomData))
-    } else {
-        Err(ErrorCode::try_from(status).unwrap())
-    }
-}
-
 pub fn theorem_register_falsity_elimination<T, U>(
     theorem_handle: T,
     term_handle: U,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Theorem>>,
     U: Into<Handle<tags::Term>>,
@@ -622,7 +598,7 @@ where
 pub fn theorem_register_conjunction_introduction<T, U>(
     left_handle: T,
     right_handle: U,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Theorem>>,
     U: Into<Handle<tags::Theorem>>,
@@ -646,7 +622,7 @@ where
 
 pub fn theorem_register_conjunction_left_elimination<T>(
     theorem_handle: T,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Theorem>>,
 {
@@ -668,7 +644,7 @@ where
 
 pub fn theorem_register_conjunction_right_elimination<T>(
     theorem_handle: T,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Theorem>>,
 {
@@ -691,7 +667,7 @@ where
 pub fn theorem_register_disjunction_left_introduction<T, U>(
     theorem_handle: T,
     term_handle: U,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Theorem>>,
     U: Into<Handle<tags::Term>>,
@@ -716,7 +692,7 @@ where
 pub fn theorem_register_disjunction_right_introduction<T, U>(
     theorem_handle: T,
     term_handle: U,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Theorem>>,
     U: Into<Handle<tags::Term>>,
@@ -742,7 +718,7 @@ pub fn theorem_register_disjunction_elimination<T, U, V>(
     left_handle: T,
     mid_handle: U,
     right_handle: V,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Theorem>>,
     U: Into<Handle<tags::Theorem>>,
@@ -769,7 +745,7 @@ where
 pub fn theorem_negation_introduction<T, U>(
     theorem_handle: T,
     term_handle: U,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Theorem>>,
     U: Into<Handle<tags::Term>>,
@@ -794,7 +770,7 @@ where
 pub fn theorem_register_negation_elimination<T, U>(
     left_handle: T,
     right_handle: U,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Theorem>>,
     U: Into<Handle<tags::Theorem>>,
@@ -819,7 +795,7 @@ where
 pub fn theorem_implication_introduction<T, U>(
     theorem_handle: T,
     term_handle: U,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Theorem>>,
     U: Into<Handle<tags::Term>>,
@@ -844,7 +820,7 @@ where
 pub fn theorem_register_implication_elimination<T, U>(
     left_handle: T,
     right_handle: U,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Theorem>>,
     U: Into<Handle<tags::Theorem>>,
@@ -869,7 +845,7 @@ where
 pub fn theorem_register_iff_introduction<T, U>(
     left_handle: T,
     right_handle: U,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Theorem>>,
     U: Into<Handle<tags::Theorem>>,
@@ -893,7 +869,7 @@ where
 
 pub fn theorem_register_iff_left_elimination<T>(
     theorem_handle: T,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Theorem>>,
 {
@@ -917,7 +893,7 @@ pub fn theorem_forall_introduction<N, T, U>(
     name_handle: N,
     type_handle: T,
     theorem_handle: U,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     N: Into<Name>,
     T: Into<Handle<tags::Type>>,
@@ -944,7 +920,7 @@ where
 pub fn theorem_forall_elimination<T, U>(
     theorem_handle: T,
     term_handle: U,
-) -> Result<Handle<tags::Term>, ErrorCode>
+) -> Result<Handle<tags::Theorem>, ErrorCode>
 where
     T: Into<Handle<tags::Theorem>>,
     U: Into<Handle<tags::Term>>,

--- a/supervisionary.iml
+++ b/supervisionary.iml
@@ -14,6 +14,7 @@
       <sourceFolder url="file://$MODULE_DIR$/tests/term/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/system-interface/src" isTestSource="false" />
       <sourceFolder url="file://$MODULE_DIR$/tests/system/src" isTestSource="false" />
+      <sourceFolder url="file://$MODULE_DIR$/tests/theorem/src" isTestSource="false" />
       <excludeFolder url="file://$MODULE_DIR$/target" />
     </content>
     <orderEntry type="inheritedJdk" />

--- a/tests/README.markdown
+++ b/tests/README.markdown
@@ -1,3 +1,26 @@
 # Tests
 
-Unit-level and module-level integration tests for the various Supervisionary components.
+Unit-level and module-level integration tests for the various Supervisionary
+components.  Directory contents:
+
+- `type_former`: tests of the Supervisionary type-former system calls and
+  preprovisioned handles to primitive type-formers.
+- `type`: tests of the Supervisionary type system calls and preprovisioned
+  handles to primitive types.
+- `constant`: tests of the Supervisionary constant system calls and
+  prprovisioned handles to primitive constants.
+- `system`: tests of the Supervisionary system access and manipulation system
+  calls.
+- `term`: tests of the Supervisionary term system calls and preprovisioned
+  handles to primitive terms.
+- `theorem`: tests of the Supervisionary theorem system calls.
+
+## Building
+
+To build, enter the relevant test directory and then:
+
+```shell
+λ > cargo build --release --target wasm32-unknown-unknown
+```
+
+The resulting binary is stored in `../target/wasm32-unknown-unknown/release/`.

--- a/tests/theorem/Cargo.toml
+++ b/tests/theorem/Cargo.toml
@@ -1,0 +1,9 @@
+[package]
+name        = "theorem"
+version     = "0.1.0"
+authors     = ["Dominic Mulligan"]
+edition     = "2018"
+description = "Tests of the theorem ABI."
+
+[dependencies]
+libsupervisionary = {path = "../../libsupervisionary"}

--- a/tests/theorem/Makefile.toml
+++ b/tests/theorem/Makefile.toml
@@ -1,0 +1,39 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.build]
+description = "Builds the Supervisionary theorem tests"
+command     = "cargo"
+args        = ["build", "--release", "--target=wasm32-unknown-unknown"]
+
+[tasks.clean]
+description = "Cleans all built thereom test object files and executables."
+command     = "cargo"
+args        = ["clean"]
+
+[tasks.test]
+description = "Runs module-level unit tests for the theorem tests."
+command     = "cargo"
+args        = ["test"]
+
+[tasks.clippy]
+description   = "Runs the Clippy linter on the theorem tests source files."
+install_crate = "clippy"
+command       = "cargo"
+args          = ["clippy"]
+
+[tasks.format]
+description   = "Formats the theorem tests source code."
+install_crate = "rustfmt"
+command       = "cargo"
+args          = ["fmt"]
+
+[tasks.document]
+description   = "Generates rustdoc documentation from the theorem tests source code."
+install_crate = "rustdoc"
+command       = "cargo"
+args          = ["doc"]
+
+[tasks.all]
+description  = "Build, lint, format, and test the Supervisionary theorem tests"
+dependencies = ["clean", "format", "build", "clippy", "test", "document"]

--- a/tests/theorem/src/main.rs
+++ b/tests/theorem/src/main.rs
@@ -1,0 +1,23 @@
+//! # Tests for the Supervisionary theorem ABI
+//!
+//! # Authors
+//!
+//! [Dominic Mulligan]
+//!
+//! # Copyright
+//!
+//! Please see the `LICENSE.markdown` file in the *Supervisionary* root
+//! directory for licensing information.
+//!
+//! [Dominic Mulligan]: https://dominicpm.github.io
+
+use libsupervisionary::raw::{system::system_io_write, theorem::*, ErrorCode};
+
+fn main() -> Result<(), ErrorCode> {
+    system_io_write(format!(
+        "PREALLOCATED_HANDLE_THEOREM_TRUTH_INTRODUCTION: {:?}\n",
+        PREALLOCATED_HANDLE_THEOREM_TRUTH_INTRODUCTION
+    ))?;
+
+    Ok(())
+}

--- a/wasmi-bindings/src/runtime_trap.rs
+++ b/wasmi-bindings/src/runtime_trap.rs
@@ -35,7 +35,7 @@ pub enum RuntimeTrap {
     /// An attempted write to the WASM guest's heap failed.
     MemoryWriteFailed,
     /// The WASM guest program tried to call a function that does not exist.
-    NoSuchFunction,
+    NoSuchFunction(usize),
     /// A type-signature check on a host-function failed.
     SignatureFailure,
 }
@@ -44,7 +44,9 @@ pub enum RuntimeTrap {
 impl Display for RuntimeTrap {
     fn fmt(&self, f: &mut Formatter) -> Result<(), DisplayError> {
         match self {
-            RuntimeTrap::NoSuchFunction => write!(f, "NoSuchFunction"),
+            RuntimeTrap::NoSuchFunction(opcode) => {
+                write!(f, "NoSuchFunction: {}", opcode)
+            }
             RuntimeTrap::SignatureFailure => write!(f, "SignatureFailure"),
             RuntimeTrap::MemoryNotRegistered => {
                 write!(f, "MemoryNotRegistered")

--- a/wasmi-bindings/src/system_call_numbers.rs
+++ b/wasmi-bindings/src/system_call_numbers.rs
@@ -323,6 +323,9 @@ pub(crate) const ABI_THEOREM_REGISTER_ASSUMPTION_NAME: &str =
 pub(crate) const ABI_THEOREM_REGISTER_WEAKEN_NAME: &str =
     "__theorem_register_weaken";
 
+/// The name of the `Theorem.Size` ABI call.
+pub(crate) const ABI_THEOREM_SIZE_NAME: &str = "__theorem_size";
+
 /// The name of the `Theorem.Register.Reflexivity` ABI call.
 pub(crate) const ABI_THEOREM_REGISTER_REFLEXIVITY_NAME: &str =
     "__theorem_register_reflexivity";
@@ -351,9 +354,6 @@ pub(crate) const ABI_THEOREM_REGISTER_SUBSTITUTE_NAME: &str =
 pub(crate) const ABI_THEOREM_REGISTER_TYPE_SUBSTITUTE_NAME: &str =
     "__theorem_register_type_substitute";
 
-/// The name of the `Theorem.Register.TruthIntroduction` ABI call.
-pub(crate) const ABI_THEOREM_REGISTER_TRUTH_INTRODUCTION_NAME: &str =
-    "__theorem_register_truth_introduction";
 /// The name of the `Theorem.Register.FalsityElimination` ABI call.
 pub(crate) const ABI_THEOREM_REGISTER_FALSITY_ELIMINATION_NAME: &str =
     "__theorem_register_falsity_elimination";
@@ -427,28 +427,29 @@ pub(crate) const ABI_THEOREM_REGISTER_ASSUMPTION_INDEX: usize = 61;
 /// The index of the `Theorem.Register.Weaken` ABI call.
 pub(crate) const ABI_THEOREM_REGISTER_WEAKEN_INDEX: usize = 62;
 
+/// The index of the `Theorem.Size` ABI call.
+pub(crate) const ABI_THEOREM_SIZE_INDEX: usize = 63;
+
 /// The index of the `Theorem.Register.Reflexivity` ABI call.
-pub(crate) const ABI_THEOREM_REGISTER_REFLEXIVITY_INDEX: usize = 63;
+pub(crate) const ABI_THEOREM_REGISTER_REFLEXIVITY_INDEX: usize = 64;
 /// The index of the `Theorem.Register.Symmetry` ABI call.
-pub(crate) const ABI_THEOREM_REGISTER_SYMMETRY_INDEX: usize = 64;
+pub(crate) const ABI_THEOREM_REGISTER_SYMMETRY_INDEX: usize = 65;
 /// The index of the `Theorem.Register.Transitivity` ABI call.
-pub(crate) const ABI_THEOREM_REGISTER_TRANSITIVITY_INDEX: usize = 65;
+pub(crate) const ABI_THEOREM_REGISTER_TRANSITIVITY_INDEX: usize = 66;
 /// The index of the `Theorem.Register.Beta` ABI call.
-pub(crate) const ABI_THEOREM_REGISTER_BETA_INDEX: usize = 66;
+pub(crate) const ABI_THEOREM_REGISTER_BETA_INDEX: usize = 67;
 /// The index of the `Theorem.Register.Eta` ABI call.
-pub(crate) const ABI_THEOREM_REGISTER_ETA_INDEX: usize = 67;
+pub(crate) const ABI_THEOREM_REGISTER_ETA_INDEX: usize = 68;
 /// The index of the `Theorem.Register.Application` ABI call.
-pub(crate) const ABI_THEOREM_REGISTER_APPLICATION_INDEX: usize = 68;
+pub(crate) const ABI_THEOREM_REGISTER_APPLICATION_INDEX: usize = 69;
 /// The index of the `Theorem.Register.Lambda` ABI call.
-pub(crate) const ABI_THEOREM_REGISTER_LAMBDA_INDEX: usize = 69;
+pub(crate) const ABI_THEOREM_REGISTER_LAMBDA_INDEX: usize = 70;
 
 /// The index of the `Theorem.Register.Substitute` ABI call.
-pub(crate) const ABI_THEOREM_REGISTER_SUBSTITUTE_INDEX: usize = 70;
+pub(crate) const ABI_THEOREM_REGISTER_SUBSTITUTE_INDEX: usize = 71;
 /// The index of the `Theorem.Register.TypeSubstitute` ABI call.
-pub(crate) const ABI_THEOREM_REGISTER_TYPE_SUBSTITUTE_INDEX: usize = 71;
+pub(crate) const ABI_THEOREM_REGISTER_TYPE_SUBSTITUTE_INDEX: usize = 72;
 
-/// The index of the `Theorem.Register.TruthIntroduction` ABI call.
-pub(crate) const ABI_THEOREM_REGISTER_TRUTH_INTRODUCTION_INDEX: usize = 72;
 /// The index of the `Theorem.Register.FalsityElimination` ABI call.
 pub(crate) const ABI_THEOREM_REGISTER_FALSITY_ELIMINATION_INDEX: usize = 73;
 

--- a/wasmi-bindings/src/type_checking.rs
+++ b/wasmi-bindings/src/type_checking.rs
@@ -945,14 +945,6 @@ pub(crate) fn check_theorem_register_eta_signature(
     )
 }
 
-/// Checks the signature of the `Theorem.Register.TruthIntroduction` ABI function.
-#[inline]
-pub(crate) fn check_theorem_register_truth_introduction_signature(
-    signature: &Signature,
-) -> bool {
-    check_signature(signature, &[AbiType::Pointer], &Some(AbiType::ErrorCode))
-}
-
 /// Checks the signature of the `Theorem.Register.FalsityElimination` ABI function.
 #[inline]
 pub(crate) fn check_theorem_register_falsity_elimination_signature(
@@ -1179,7 +1171,17 @@ pub(crate) fn check_theorem_split_hypotheses_signature(
 ) -> bool {
     check_signature(
         signature,
-        &[AbiType::Handle, AbiType::Pointer, AbiType::Size],
+        &[AbiType::Handle, AbiType::Pointer, AbiType::Pointer],
+        &Some(AbiType::ErrorCode),
+    )
+}
+
+/// Checks the signature of the `Theorem.Size` ABI function.
+#[inline]
+pub(crate) fn check_theorem_size_signature(signature: &Signature) -> bool {
+    check_signature(
+        signature,
+        &[AbiType::Handle, AbiType::Pointer],
         &Some(AbiType::ErrorCode),
     )
 }


### PR DESCRIPTION
Implemented Theorem.Size system call which is used for allocating appropriate
buffers in user-space for holding dynamic content (e.g., free variables, the
premisses) of a theorem.

Added initial plumbing of Theorem.Register.Weaken system call for weakening
theorems with an additional premiss.

Demoted Theorem.Register.Truth.Introduction from a system call to a
preprovisioned primitive constant.  The premisses of truth introduction are now
fixed at the empty context, rather than being allowed to vary as a result of a
system call.

Fixed various bugs in `libsupervisionary` bindings to theorem-related system
calls.

Bumped version number of `clap` dependency in `driver`.

Updated `README.markdown` in `tests` with details of what is being tested in
each series of testbenches.

Added Makefile.toml for theorem tests.  Added new `theorem-integration-test`
workspace-level build target, and added as a new dependency to
`integration-tests` target.

Fixed issues highlighted by Clippy, and issues when generating `rustdoc`
documentation.