### PR TITLE
Adopted cargo-make as the project build tool

### DIFF
--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,36 @@
+# Supervisionary project-level Makefile
+
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.constant-integration-test]
+description  = "Run the driver executable on the constant tests."
+env          = { "RUST_LOG" = "info" }
+script       = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/target/release/driver --binary=${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/target/wasm32-unknown-unknown/release/constant.wasm"
+
+[tasks.system-integration-test]
+description  = "Run the driver executable on the system tests."
+env          = { "RUST_LOG" = "info" }
+script       = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/target/release/driver --binary=${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/target/wasm32-unknown-unknown/release/system.wasm"
+
+[tasks.term-integration-test]
+description  = "Run the driver executable on the term tests."
+env          = { "RUST_LOG" = "info" }
+script       = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/target/release/driver --binary=${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/target/wasm32-unknown-unknown/release/term.wasm"
+
+[tasks.type-integration-test]
+description  = "Run the driver executable on the type tests."
+env          = { "RUST_LOG" = "info" }
+script       = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/target/release/driver --binary=${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/target/wasm32-unknown-unknown/release/type.wasm"
+
+[tasks.type-former-integration-test]
+description  = "Run the driver executable on the type-former tests."
+env          = { "RUST_LOG" = "info" }
+script       = "${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/target/release/driver --binary=${CARGO_MAKE_CURRENT_TASK_INITIAL_MAKEFILE_DIRECTORY}/target/wasm32-unknown-unknown/release/type_former.wasm"
+
+[tasks.build-indirection]
+run_task = { name = ["build"], fork = true }
+
+[tasks.integration-tests]
+workspace = false
+run_task = { name = ["build-indirection", "constant-integration-test", "system-integration-test", "term-integration-test", "type-integration-test", "type-former-integration-test"] }

--- a/README.markdown
+++ b/README.markdown
@@ -49,51 +49,39 @@ These can be executed using `driver`, as explained below.
 See the `LICENSE` file in the Supervisionary root directory for full details of
 the MIT open-source license that Supervisionary is licensed under.
 
-## Tests
+## Build instructions
 
-To execute the Supervisionary tests, perform the following steps:
-
-### Compile `driver`
-
-Perform the following steps, starting from the Supervisionary root directory:
+Assuming a semi-recent Rust toolchain installation, first install `cargo-make`:
 
 ```shell
-λ > cd driver
-λ > cargo build --release
+λ > cargo install cargo-make
 ```
 
-### Compile the tests
-
-Perform the following steps, starting from the Supervisionary root directory:
+Moreover, make sure the `wasm32-unknown-unknown` toolchain is installed, as
+follows:
 
 ```shell
-λ > cd tests/type
-λ > cargo build --release --target wasm32-unknown-unknown
+λ > rustup target install wasm32-unknown-unknown
 ```
 
-Note that this requires that the `wasm32-unknown-unknown` target is installed.
-To do this:
+Then to compile all Supervisionary components, do:
 
 ```shell
-λ > rustup target add wasm32-unknown-unknown
+λ > cargo make build
 ```
 
-### Run the tests
-
-All built binaries are installed in the `target` directory which is created
-under the Supervisionary root directory.  Run `driver` as follows:
+To compile and execute Supervisionary's integration tests, do:
 
 ```shell
-λ > ./target/release/driver --binary target/wasm32-unknown-unknown/release/type.wasm
+λ > cargo make integration-tests
 ```
 
-The `driver` application will load the binary and begin executing the `main`
-function within.  This should print "Wasm module executed successfully" and
-produce a `0` return code.  To produce more verbose output, turn the Rust
-logging level up as follows:
+To build Supervisionary documentation, do:
 
 ```shell
-λ > RUST_LOG=info ./target/release/driver --binary target/wasm32-unknown-unknown/release/type.wasm
+λ > cargo make document
 ```
 
-This should produce a full trace of the kernel's activity.
+Note that generated documentation is placed in `./target/doc` in the
+Supervisionary root directory.
+

--- a/driver/Makefile.toml
+++ b/driver/Makefile.toml
@@ -1,0 +1,39 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.build]
+description = "Builds the Supervisionary driver."
+command     = "cargo"
+args        = ["build", "--release"]
+
+[tasks.clean]
+description = "Cleans all built driver object files and executables."
+command     = "cargo"
+args        = ["clean"]
+
+[tasks.test]
+description = "Runs module-level unit tests for the driver."
+command     = "cargo"
+args        = ["test"]
+
+[tasks.clippy]
+description   = "Runs the Clippy linter on the driver source files."
+install_crate = "clippy"
+command       = "cargo"
+args          = ["clippy"]
+
+[tasks.format]
+description   = "Formats the driver source code."
+install_crate = "rustfmt"
+command       = "cargo"
+args          = ["fmt"]
+
+[tasks.document]
+description   = "Generates rustdoc documentation from the driver source code."
+install_crate = "rustdoc"
+command       = "cargo"
+args          = ["doc"]
+
+[tasks.all]
+description  = "Build, lint, format, and test the driver."
+dependencies = ["clean", "format", "build", "clippy", "test", "document"]

--- a/driver/src/main.rs
+++ b/driver/src/main.rs
@@ -15,9 +15,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use clap::{App, Arg};
 use log::info;
@@ -151,9 +151,9 @@ fn main() {
 
     let command_line_args = parse_command_line_arguments();
 
-    let binary = load_binary(&command_line_args.wasm_binary_path);
+    let binary = load_binary(command_line_args.wasm_binary_path);
 
-    let loaded_module = Module::from_buffer(&binary).unwrap_or_else(|e| {
+    let loaded_module = Module::from_buffer(binary).unwrap_or_else(|e| {
         eprintln!("Failed to load Wasm module.  Error produced: {}.", e);
         exit(1);
     });

--- a/kernel/Makefile.toml
+++ b/kernel/Makefile.toml
@@ -1,0 +1,39 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.build]
+description = "Builds the Supervisionary kernel"
+command     = "cargo"
+args        = ["build", "--release"]
+
+[tasks.clean]
+description = "Cleans all built kernel object files and executables."
+command     = "cargo"
+args        = ["clean"]
+
+[tasks.test]
+description = "Runs module-level unit tests for the kernel."
+command     = "cargo"
+args        = ["test"]
+
+[tasks.clippy]
+description   = "Runs the Clippy linter on the kernel source files."
+install_crate = "clippy"
+command       = "cargo"
+args          = ["clippy"]
+
+[tasks.format]
+description   = "Formats the kernel source code."
+install_crate = "rustfmt"
+command       = "cargo"
+args          = ["fmt"]
+
+[tasks.document]
+description   = "Generates rustdoc documentation from the kernel source code."
+install_crate = "rustdoc"
+command       = "cargo"
+args          = ["doc"]
+
+[tasks.all]
+description  = "Build, lint, format, and test the Supervisionary kernel"
+dependencies = ["clean", "format", "build", "clippy", "test", "document"]

--- a/kernel/src/_type.rs
+++ b/kernel/src/_type.rs
@@ -3,8 +3,8 @@
 //! HOL uses simple-types with top-level polymorphism.  The grammar of types
 //! is recursively defined as follows:
 //!
-//! ```
-//!     τ, τʹ, ... ::= ⍺ | F(τ₁, ..., τₙ)
+//! ```text
+//! τ, τʹ, ... ::= ⍺ | F(τ₁, ..., τₙ)
 //! ```
 //!
 //! Here, ⍺ ranges arbitrarily over a set of *type variables* whilst `F` ranges
@@ -29,9 +29,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use crate::{
     handle::{

--- a/kernel/src/error_code.rs
+++ b/kernel/src/error_code.rs
@@ -24,9 +24,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use std::{
     convert::TryFrom,
@@ -175,7 +175,7 @@ impl Display for ErrorCode {
 }
 
 /* XXX: this is a horror show, as we're forced to either have an-almost false
- * dependency on WASMI in this crate to declare `ErrorCode` to be an
+ * dependency on Wasmi in this crate to declare `ErrorCode` to be an
  * instantiation of the `HostError` crate, or have a duplicate copy of the
  * `HostError` type in the `wasmi-bindings` crate to work around the rules about
  * trait instantiations in Rust.
@@ -183,10 +183,9 @@ impl Display for ErrorCode {
 #[cfg(feature = "wasmi-hosterror")]
 impl HostError for ErrorCode {}
 
-/// Conversion into an `i32` type for ABI transport.
-impl Into<i32> for ErrorCode {
-    fn into(self) -> i32 {
-        match self {
+impl From<ErrorCode> for i32 {
+    fn from(value: ErrorCode) -> Self {
+        match value {
             ErrorCode::Success => 0,
             ErrorCode::NoSuchFunction => 1,
             ErrorCode::NoSuchConstantRegistered => 2,

--- a/kernel/src/handle.rs
+++ b/kernel/src/handle.rs
@@ -17,9 +17,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use std::{
     fmt,

--- a/kernel/src/kernel_panic.rs
+++ b/kernel/src/kernel_panic.rs
@@ -28,9 +28,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 ////////////////////////////////////////////////////////////////////////////////
 // Kernel panic messages.

--- a/kernel/src/name.rs
+++ b/kernel/src/name.rs
@@ -19,9 +19,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 ////////////////////////////////////////////////////////////////////////////////
 // Miscellaneous material.

--- a/kernel/src/runtime_state.rs
+++ b/kernel/src/runtime_state.rs
@@ -19,9 +19,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use crate::{
     _type::{
@@ -501,8 +501,10 @@ impl RuntimeState {
     /// `handle`.  Here, size is defined recursively on the structure of types
     /// by:
     ///
-    ///     size(Variable(n)) = 1
-    ///     size(Combination(f, a_1, ..., a_n) = 1 + size(a_1) + ... + size(a_n)
+    /// ```text
+    /// size(Variable(n)) = 1
+    /// size(Combination(f, a_1, ..., a_n) = 1 + size(a_1) + ... + size(a_n)
+    /// ```
     ///
     /// # Errors
     ///

--- a/kernel/src/term.rs
+++ b/kernel/src/term.rs
@@ -3,8 +3,8 @@
 //! HOL's terms are the terms of the explicitly-typed λ-calculus, extended with
 //! constants.  The grammar is recursively-defined, as follows:
 //!
-//! ```
-//!     r,s,t ::= x:τ | C:τ | rs | λx:τ. r
+//! ```text
+//! r,s,t ::= x:τ | C:τ | rs | λx:τ. r
 //! ```
 //!
 //! Here, to each type `τ` we associate a countably-infinite set of *variables*.
@@ -54,9 +54,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale] https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use crate::{
     handle::{

--- a/kernel/src/theorem.rs
+++ b/kernel/src/theorem.rs
@@ -29,9 +29,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use crate::handle::{tags, Handle};
 

--- a/libsupervisionary/Makefile.toml
+++ b/libsupervisionary/Makefile.toml
@@ -1,0 +1,39 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.build]
+description = "Builds libsupervisionary"
+command     = "cargo"
+args        = ["build", "--release", "--target=wasm32-unknown-unknown"]
+
+[tasks.clean]
+description = "Cleans all built libsupervisionary object files."
+command     = "cargo"
+args        = ["clean"]
+
+[tasks.test]
+description = "Runs module-level unit tests for libsupervisionary."
+command     = "cargo"
+args        = ["test"]
+
+[tasks.clippy]
+description   = "Runs the Clippy linter on libsupervisionary."
+install_crate = "clippy"
+command       = "cargo"
+args          = ["clippy"]
+
+[tasks.format]
+description   = "Formats the libsupervisionary source code."
+install_crate = "rustfmt"
+command       = "cargo"
+args          = ["fmt"]
+
+[tasks.document]
+description   = "Generates rustdoc documentation from the libsupervisionary source code."
+install_crate = "rustdoc"
+command       = "cargo"
+args          = ["doc"]
+
+[tasks.all]
+description  = "Build, lint, format, and test libsupervisionary"
+dependencies = ["clean", "format", "build", "clippy", "test", "document"]

--- a/libsupervisionary/src/build/mod.rs
+++ b/libsupervisionary/src/build/mod.rs
@@ -1,1 +1,2 @@
-
+pub mod _type;
+pub mod term;

--- a/libsupervisionary/src/lib.rs
+++ b/libsupervisionary/src/lib.rs
@@ -15,9 +15,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 pub mod build;
 pub mod raw;

--- a/libsupervisionary/src/raw/_type.rs
+++ b/libsupervisionary/src/raw/_type.rs
@@ -11,9 +11,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use crate::raw::{tags, ErrorCode, Handle, Name, RawHandle};
 use std::{

--- a/libsupervisionary/src/raw/constant.rs
+++ b/libsupervisionary/src/raw/constant.rs
@@ -11,9 +11,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use crate::raw::{tags, ErrorCode, Handle, RawHandle};
 use std::{convert::TryFrom, marker::PhantomData};

--- a/libsupervisionary/src/raw/mod.rs
+++ b/libsupervisionary/src/raw/mod.rs
@@ -11,9 +11,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use std::{
     convert::TryFrom,
@@ -174,9 +174,9 @@ impl Display for ErrorCode {
 }
 
 /// Conversion into an `i32` type for ABI transport.
-impl Into<i32> for ErrorCode {
-    fn into(self) -> i32 {
-        match self {
+impl From<ErrorCode> for i32 {
+    fn from(value: ErrorCode) -> Self {
+        match value {
             ErrorCode::NoSuchFunction => 1,
             ErrorCode::NoSuchConstantRegistered => 2,
             ErrorCode::NoSuchTermRegistered => 3,

--- a/libsupervisionary/src/raw/system.rs
+++ b/libsupervisionary/src/raw/system.rs
@@ -9,7 +9,7 @@
 //! Please see the `LICENSE.markdown` file in the *Supervisionary* root
 //! directory for licensing information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
+//! [Dominic Mulligan]<https://dominicpm.github.io>
 
 use crate::raw::ErrorCode;
 use std::convert::TryFrom;

--- a/libsupervisionary/src/raw/term.rs
+++ b/libsupervisionary/src/raw/term.rs
@@ -11,9 +11,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use crate::raw::{tags, ErrorCode, Handle, Name, RawHandle};
 use std::{

--- a/libsupervisionary/src/raw/theorem.rs
+++ b/libsupervisionary/src/raw/theorem.rs
@@ -10,8 +10,7 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
 
 use crate::raw::{tags, ErrorCode, Handle, Name, RawHandle};
 use std::{convert::TryFrom, marker::PhantomData};
@@ -928,7 +927,7 @@ where
 
     let status = unsafe {
         __theorem_register_forall_introduction(
-            name_handle.into() as u64,
+            name_handle.into(),
             *type_handle.into() as u64,
             *theorem_handle.into() as u64,
             &mut result as *mut u64,

--- a/libsupervisionary/src/raw/type_former.rs
+++ b/libsupervisionary/src/raw/type_former.rs
@@ -11,9 +11,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use crate::raw::{tags, Arity, ErrorCode, Handle, RawHandle};
 use std::{convert::TryFrom, marker::PhantomData};

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -195,10 +195,6 @@ max_width = 80
 # Default: false
 reorder_imports = true
 
-# Reorder lists of names in import statements alphabetically.
-# Default: false
-reorder_imported_names = true
-
 # Maximum line length for single line if-else expressions.
 # A value of zero means always break if-else expressions.
 # Default: 50

--- a/system-interface/Cargo.toml
+++ b/system-interface/Cargo.toml
@@ -6,8 +6,3 @@ edition     = "2018"
 description = "A system interface for querying and manipulating the system."
 
 [dependencies]
-
-[profile.release]
-lto           = true
-opt-level     = 3
-codegen-units = 1

--- a/system-interface/Makefile.toml
+++ b/system-interface/Makefile.toml
@@ -1,0 +1,39 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.build]
+description = "Builds the Supervisionary system interface."
+command     = "cargo"
+args        = ["build", "--release"]
+
+[tasks.clean]
+description = "Cleans all built system interface object files."
+command     = "cargo"
+args        = ["clean"]
+
+[tasks.test]
+description = "Runs module-level unit tests for the Supervisionary system interface."
+command     = "cargo"
+args        = ["test"]
+
+[tasks.clippy]
+description   = "Runs the Clippy linter on the Supervisionary system interface."
+install_crate = "clippy"
+command       = "cargo"
+args          = ["clippy"]
+
+[tasks.format]
+description   = "Formats the Supervisionary system interface source code."
+install_crate = "rustfmt"
+command       = "cargo"
+args          = ["fmt"]
+
+[tasks.document]
+description   = "Generates rustdoc documentation from the Supervisionary system interface source code."
+install_crate = "rustdoc"
+command       = "cargo"
+args          = ["doc"]
+
+[tasks.all]
+description  = "Build, lint, format, and test the Supervisionary system interface."
+dependencies = ["clean", "format", "build", "clippy", "test", "document"]

--- a/system-interface/src/lib.rs
+++ b/system-interface/src/lib.rs
@@ -9,7 +9,7 @@
 //! Please see the `LICENSE.markdown` file in the *Supervisionary* root
 //! directory for licensing information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
+//! [Dominic Mulligan]<https://dominicpm.github.io>
 
 pub mod pass_through;
 

--- a/system-interface/src/pass_through.rs
+++ b/system-interface/src/pass_through.rs
@@ -13,7 +13,7 @@
 //! Please see the `LICENSE.markdown` file in the *Supervisionary* root
 //! directory for licensing information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
+//! [Dominic Mulligan]<https://dominicpm.github.io>
 
 use super::SystemInterface;
 use std::io::{stderr, stdout, Write};
@@ -50,12 +50,12 @@ impl SystemInterface for PassThroughSystemInterface {
     /// Writes a string, `s`, to the system's `stdout` file handle.
     #[inline]
     fn write(&self, s: String) {
-        stdout().write(s.as_bytes()).unwrap();
+        stdout().write_all(s.as_bytes()).unwrap();
     }
 
     /// Writes a string, `s`, to the system's `stderr` file handle.
     #[inline]
     fn write_error(&self, s: String) {
-        stderr().write(s.as_bytes()).unwrap();
+        stderr().write_all(s.as_bytes()).unwrap();
     }
 }

--- a/tests/constant/Cargo.toml
+++ b/tests/constant/Cargo.toml
@@ -7,8 +7,3 @@ description = "Tests of the constant ABI."
 
 [dependencies]
 libsupervisionary = {path = "../../libsupervisionary"}
-
-[profile.release]
-lto           = true
-opt-level     = 3
-codegen-units = 1

--- a/tests/constant/Makefile.toml
+++ b/tests/constant/Makefile.toml
@@ -1,0 +1,39 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.build]
+description = "Builds the Supervisionary constant tests"
+command     = "cargo"
+args        = ["build", "--release", "--target=wasm32-unknown-unknown"]
+
+[tasks.clean]
+description = "Cleans all built constant tests object files and executables."
+command     = "cargo"
+args        = ["clean"]
+
+[tasks.test]
+description = "Runs module-level unit tests for the constant tests."
+command     = "cargo"
+args        = ["test"]
+
+[tasks.clippy]
+description   = "Runs the Clippy linter on the constant tests source files."
+install_crate = "clippy"
+command       = "cargo"
+args          = ["clippy"]
+
+[tasks.format]
+description   = "Formats the constant tests source code."
+install_crate = "rustfmt"
+command       = "cargo"
+args          = ["fmt"]
+
+[tasks.document]
+description   = "Generates rustdoc documentation from the constant tests source code."
+install_crate = "rustdoc"
+command       = "cargo"
+args          = ["doc"]
+
+[tasks.all]
+description  = "Build, lint, format, and test the Supervisionary constant tests"
+dependencies = ["clean", "format", "build", "clippy", "test", "document"]

--- a/tests/constant/src/main.rs
+++ b/tests/constant/src/main.rs
@@ -9,7 +9,7 @@
 //! Please see the `LICENSE.markdown` file in the *Supervisionary* root
 //! directory for licensing information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
+//! [Dominic Mulligan]<https://dominicpm.github.io>
 
 use libsupervisionary::raw::{
     _type::{

--- a/tests/system/Cargo.toml
+++ b/tests/system/Cargo.toml
@@ -8,7 +8,3 @@ description = "Tests of the system ABI."
 [dependencies]
 libsupervisionary = {path = "../../libsupervisionary"}
 
-[profile.release]
-lto           = true
-opt-level     = 3
-codegen-units = 1

--- a/tests/system/Makefile.toml
+++ b/tests/system/Makefile.toml
@@ -1,0 +1,39 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.build]
+description = "Builds the Supervisionary system tests"
+command     = "cargo"
+args        = ["build", "--release", "--target=wasm32-unknown-unknown"]
+
+[tasks.clean]
+description = "Cleans all built system tests object files and executables."
+command     = "cargo"
+args        = ["clean"]
+
+[tasks.test]
+description = "Runs module-level unit tests for the system tests."
+command     = "cargo"
+args        = ["test"]
+
+[tasks.clippy]
+description   = "Runs the Clippy linter on the system tests source files."
+install_crate = "clippy"
+command       = "cargo"
+args          = ["clippy"]
+
+[tasks.format]
+description   = "Formats the system tests source code."
+install_crate = "rustfmt"
+command       = "cargo"
+args          = ["fmt"]
+
+[tasks.document]
+description   = "Generates rustdoc documentation from the system tests source code."
+install_crate = "rustdoc"
+command       = "cargo"
+args          = ["doc"]
+
+[tasks.all]
+description  = "Build, lint, format, and test the Supervisionary system tests"
+dependencies = ["clean", "format", "build", "clippy", "test", "document"]

--- a/tests/system/src/main.rs
+++ b/tests/system/src/main.rs
@@ -9,12 +9,14 @@
 //! Please see the `LICENSE.markdown` file in the *Supervisionary* root
 //! directory for licensing information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
+//! [Dominic Mulligan]<https://dominicpm.github.io>
 
-use libsupervisionary::raw::system::*;
+use libsupervisionary::raw::{system::*, ErrorCode};
 
-fn main() {
-    system_io_write("Hello, world!");
+fn main() -> Result<(), ErrorCode> {
+    system_io_write("Hello, world!")?;
 
-    system_io_write_error("Error!  Error!");
+    system_io_write_error("Error!  Error!")?;
+
+    Ok(())
 }

--- a/tests/term/Cargo.toml
+++ b/tests/term/Cargo.toml
@@ -7,8 +7,3 @@ description = "Tests of the term ABI."
 
 [dependencies]
 libsupervisionary = {path = "../../libsupervisionary"}
-
-[profile.release]
-lto           = true
-opt-level     = 3
-codegen-units = 1

--- a/tests/term/Makefile.toml
+++ b/tests/term/Makefile.toml
@@ -1,0 +1,39 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.build]
+description = "Builds the Supervisionary term tests"
+command     = "cargo"
+args        = ["build", "--release", "--target=wasm32-unknown-unknown"]
+
+[tasks.clean]
+description = "Cleans all built term tests object files and executables."
+command     = "cargo"
+args        = ["clean"]
+
+[tasks.test]
+description = "Runs module-level unit tests for the term tests."
+command     = "cargo"
+args        = ["test"]
+
+[tasks.clippy]
+description   = "Runs the Clippy linter on the term tests source files."
+install_crate = "clippy"
+command       = "cargo"
+args          = ["clippy"]
+
+[tasks.format]
+description   = "Formats the term tests source code."
+install_crate = "rustfmt"
+command       = "cargo"
+args          = ["fmt"]
+
+[tasks.document]
+description   = "Generates rustdoc documentation from the term tests source code."
+install_crate = "rustdoc"
+command       = "cargo"
+args          = ["doc"]
+
+[tasks.all]
+description  = "Build, lint, format, and test the Supervisionary term tests"
+dependencies = ["clean", "format", "build", "clippy", "test", "document"]

--- a/tests/term/src/main.rs
+++ b/tests/term/src/main.rs
@@ -9,7 +9,7 @@
 //! Please see the `LICENSE.markdown` file in the *Supervisionary* root
 //! directory for licensing information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
+//! [Dominic Mulligan]<https://dominicpm.github.io>
 
 use libsupervisionary::raw::{
     _type::{

--- a/tests/type/Cargo.toml
+++ b/tests/type/Cargo.toml
@@ -7,8 +7,3 @@ description = "Tests of the type ABI."
 
 [dependencies]
 libsupervisionary = {path = "../../libsupervisionary"}
-
-[profile.release]
-lto           = true
-opt-level     = 3
-codegen-units = 1

--- a/tests/type/Makefile.toml
+++ b/tests/type/Makefile.toml
@@ -1,0 +1,39 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.build]
+description = "Builds the Supervisionary type tests"
+command     = "cargo"
+args        = ["build", "--release", "--target=wasm32-unknown-unknown"]
+
+[tasks.clean]
+description = "Cleans all built type tests object files and executables."
+command     = "cargo"
+args        = ["clean"]
+
+[tasks.test]
+description = "Runs module-level unit tests for the type tests."
+command     = "cargo"
+args        = ["test"]
+
+[tasks.clippy]
+description   = "Runs the Clippy linter on the type tests source files."
+install_crate = "clippy"
+command       = "cargo"
+args          = ["clippy"]
+
+[tasks.format]
+description   = "Formats the type tests source code."
+install_crate = "rustfmt"
+command       = "cargo"
+args          = ["fmt"]
+
+[tasks.document]
+description   = "Generates rustdoc documentation from the type tests source code."
+install_crate = "rustdoc"
+command       = "cargo"
+args          = ["doc"]
+
+[tasks.all]
+description  = "Build, lint, format, and test the Supervisionary type tests"
+dependencies = ["clean", "format", "build", "clippy", "test", "document"]

--- a/tests/type/src/main.rs
+++ b/tests/type/src/main.rs
@@ -11,9 +11,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use libsupervisionary::raw::{
     _type::*,

--- a/tests/type_former/Cargo.toml
+++ b/tests/type_former/Cargo.toml
@@ -7,8 +7,3 @@ description = "Tests of the type-former ABI."
 
 [dependencies]
 libsupervisionary = {path = "../../libsupervisionary"}
-
-[profile.release]
-lto           = true
-opt-level     = 3
-codegen-units = 1

--- a/tests/type_former/Makefile.toml
+++ b/tests/type_former/Makefile.toml
@@ -1,0 +1,39 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.build]
+description = "Builds the Supervisionary type-former tests"
+command     = "cargo"
+args        = ["build", "--release", "--target=wasm32-unknown-unknown"]
+
+[tasks.clean]
+description = "Cleans all built type-former tests object files and executables."
+command     = "cargo"
+args        = ["clean"]
+
+[tasks.test]
+description = "Runs module-level unit tests for the type-former tests."
+command     = "cargo"
+args        = ["test"]
+
+[tasks.clippy]
+description   = "Runs the Clippy linter on the type-former tests source files."
+install_crate = "clippy"
+command       = "cargo"
+args          = ["clippy"]
+
+[tasks.format]
+description   = "Formats the type-former tests source code."
+install_crate = "rustfmt"
+command       = "cargo"
+args          = ["fmt"]
+
+[tasks.document]
+description   = "Generates rustdoc documentation from the type-former tests source code."
+install_crate = "rustdoc"
+command       = "cargo"
+args          = ["doc"]
+
+[tasks.all]
+description  = "Build, lint, format, and test the Supervisionary type-former tests"
+dependencies = ["clean", "format", "build", "clippy", "test", "document"]

--- a/tests/type_former/src/main.rs
+++ b/tests/type_former/src/main.rs
@@ -11,9 +11,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use libsupervisionary::raw::type_former::*;
 

--- a/wasmi-bindings/Cargo.toml
+++ b/wasmi-bindings/Cargo.toml
@@ -13,8 +13,3 @@ lazy_static      = "1.4.0"
 log              = "0.4.14"
 system-interface = { path = "../system-interface" }
 wasmi            = "0.9.0"
-
-[profile.release]
-lto           = true
-opt-level     = 3
-codegen-units = 1

--- a/wasmi-bindings/Makefile.toml
+++ b/wasmi-bindings/Makefile.toml
@@ -1,0 +1,39 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+
+[tasks.build]
+description = "Builds Wasmi bindings for the kernel."
+command     = "cargo"
+args        = ["build", "--release"]
+
+[tasks.clean]
+description = "Cleans all built Wasmi binding object files."
+command     = "cargo"
+args        = ["clean"]
+
+[tasks.test]
+description = "Runs module-level unit tests for the Wasmi bindings."
+command     = "cargo"
+args        = ["test"]
+
+[tasks.clippy]
+description   = "Runs the Clippy linter on the Wasmi bindings."
+install_crate = "clippy"
+command       = "cargo"
+args          = ["clippy"]
+
+[tasks.format]
+description   = "Formats the Wasmi bindings source code."
+install_crate = "rustfmt"
+command       = "cargo"
+args          = ["fmt"]
+
+[tasks.document]
+description   = "Generates rustdoc documentation from the Wasmi bindings source code."
+install_crate = "rustdoc"
+command       = "cargo"
+args          = ["doc"]
+
+[tasks.all]
+description  = "Build, lint, format, and test the Wasmi bindings."
+dependencies = ["clean", "format", "build", "clippy", "test", "document"]

--- a/wasmi-bindings/src/lib.rs
+++ b/wasmi-bindings/src/lib.rs
@@ -16,9 +16,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 pub mod runtime_state;
 mod runtime_trap;

--- a/wasmi-bindings/src/runtime_state.rs
+++ b/wasmi-bindings/src/runtime_state.rs
@@ -19,9 +19,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use std::{borrow::Borrow, cell::RefCell, fmt::Debug, mem::size_of};
 

--- a/wasmi-bindings/src/runtime_trap.rs
+++ b/wasmi-bindings/src/runtime_trap.rs
@@ -15,9 +15,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use kernel::error_code::ErrorCode;
 use std::fmt::{Display, Error as DisplayError, Formatter};

--- a/wasmi-bindings/src/system_call_numbers.rs
+++ b/wasmi-bindings/src/system_call_numbers.rs
@@ -13,9 +13,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 ////////////////////////////////////////////////////////////////////////////////
 // Proof-related system calls.

--- a/wasmi-bindings/src/system_interface_types.rs
+++ b/wasmi-bindings/src/system_interface_types.rs
@@ -14,9 +14,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use wasmi::ValueType;
 

--- a/wasmi-bindings/src/type_checking.rs
+++ b/wasmi-bindings/src/type_checking.rs
@@ -14,9 +14,9 @@
 //! `LICENSE.markdown` file in the *Supervisionary* root directory for licensing
 //! information.
 //!
-//! [Dominic Mulligan]: https://dominicpm.github.io
-//! [Nick Spinale]: https://nickspinale.com
-//! [Arm Research]: http://www.arm.com/research
+//! [Dominic Mulligan]<https://dominicpm.github.io>
+//! [Nick Spinale]<https://nickspinale.com>
+//! [Arm Research]<http://www.arm.com/research>
 
 use crate::system_interface_types::AbiType;
 use wasmi::Signature;


### PR DESCRIPTION
Adopted cargo-make as the project build tool.

Provided targets for building, testing, linting, documenting, and performing project-wide integration tests.

Fixed various issues stopping documentation from being generated.

Fixed various issues dredged up by cargo-clippy.

Updated README.markdown.

Signed-off-by: Dominic Mulligan <dominic.p.mulligan@gmail.com>