### PR TITLE
Stopped document generation for project dependencies

### DIFF
--- a/driver/Makefile.toml
+++ b/driver/Makefile.toml
@@ -32,7 +32,7 @@ args          = ["fmt"]
 description   = "Generates rustdoc documentation from the driver source code."
 install_crate = "rustdoc"
 command       = "cargo"
-args          = ["doc"]
+args          = ["doc", "--no-deps"]
 
 [tasks.all]
 description  = "Build, lint, format, and test the driver."

--- a/kernel/Makefile.toml
+++ b/kernel/Makefile.toml
@@ -32,7 +32,7 @@ args          = ["fmt"]
 description   = "Generates rustdoc documentation from the kernel source code."
 install_crate = "rustdoc"
 command       = "cargo"
-args          = ["doc"]
+args          = ["doc", "--no-deps"]
 
 [tasks.all]
 description  = "Build, lint, format, and test the Supervisionary kernel"

--- a/libsupervisionary/Makefile.toml
+++ b/libsupervisionary/Makefile.toml
@@ -32,7 +32,7 @@ args          = ["fmt"]
 description   = "Generates rustdoc documentation from the libsupervisionary source code."
 install_crate = "rustdoc"
 command       = "cargo"
-args          = ["doc"]
+args          = ["doc", "--no-deps"]
 
 [tasks.all]
 description  = "Build, lint, format, and test libsupervisionary"

--- a/system-interface/Makefile.toml
+++ b/system-interface/Makefile.toml
@@ -32,7 +32,7 @@ args          = ["fmt"]
 description   = "Generates rustdoc documentation from the Supervisionary system interface source code."
 install_crate = "rustdoc"
 command       = "cargo"
-args          = ["doc"]
+args          = ["doc", "--no-deps"]
 
 [tasks.all]
 description  = "Build, lint, format, and test the Supervisionary system interface."

--- a/tests/constant/Makefile.toml
+++ b/tests/constant/Makefile.toml
@@ -32,7 +32,7 @@ args          = ["fmt"]
 description   = "Generates rustdoc documentation from the constant tests source code."
 install_crate = "rustdoc"
 command       = "cargo"
-args          = ["doc"]
+args          = ["doc", "--no-deps"]
 
 [tasks.all]
 description  = "Build, lint, format, and test the Supervisionary constant tests"

--- a/tests/system/Makefile.toml
+++ b/tests/system/Makefile.toml
@@ -32,7 +32,7 @@ args          = ["fmt"]
 description   = "Generates rustdoc documentation from the system tests source code."
 install_crate = "rustdoc"
 command       = "cargo"
-args          = ["doc"]
+args          = ["doc", "--no-deps"]
 
 [tasks.all]
 description  = "Build, lint, format, and test the Supervisionary system tests"

--- a/tests/term/Makefile.toml
+++ b/tests/term/Makefile.toml
@@ -32,7 +32,7 @@ args          = ["fmt"]
 description   = "Generates rustdoc documentation from the term tests source code."
 install_crate = "rustdoc"
 command       = "cargo"
-args          = ["doc"]
+args          = ["doc", "--no-deps"]
 
 [tasks.all]
 description  = "Build, lint, format, and test the Supervisionary term tests"

--- a/tests/theorem/Makefile.toml
+++ b/tests/theorem/Makefile.toml
@@ -32,7 +32,7 @@ args          = ["fmt"]
 description   = "Generates rustdoc documentation from the theorem tests source code."
 install_crate = "rustdoc"
 command       = "cargo"
-args          = ["doc"]
+args          = ["doc", "--no-deps"]
 
 [tasks.all]
 description  = "Build, lint, format, and test the Supervisionary theorem tests"

--- a/tests/type/Makefile.toml
+++ b/tests/type/Makefile.toml
@@ -32,7 +32,7 @@ args          = ["fmt"]
 description   = "Generates rustdoc documentation from the type tests source code."
 install_crate = "rustdoc"
 command       = "cargo"
-args          = ["doc"]
+args          = ["doc", "--no-deps"]
 
 [tasks.all]
 description  = "Build, lint, format, and test the Supervisionary type tests"

--- a/tests/type_former/Makefile.toml
+++ b/tests/type_former/Makefile.toml
@@ -32,7 +32,7 @@ args          = ["fmt"]
 description   = "Generates rustdoc documentation from the type-former tests source code."
 install_crate = "rustdoc"
 command       = "cargo"
-args          = ["doc"]
+args          = ["doc", "--no-deps"]
 
 [tasks.all]
 description  = "Build, lint, format, and test the Supervisionary type-former tests"

--- a/wasmi-bindings/Makefile.toml
+++ b/wasmi-bindings/Makefile.toml
@@ -32,7 +32,7 @@ args          = ["fmt"]
 description   = "Generates rustdoc documentation from the Wasmi bindings source code."
 install_crate = "rustdoc"
 command       = "cargo"
-args          = ["doc"]
+args          = ["doc", "--no-deps"]
 
 [tasks.all]
 description  = "Build, lint, format, and test the Wasmi bindings."


### PR DESCRIPTION
Added `--no-deps` to `cargo doc` targets to remove document generation for project dependencies and speed up the generation process.