### PR TITLE
Reworked the system interface

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -177,9 +177,9 @@ checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "libc"
-version = "0.2.137"
+version = "0.2.138"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc7fcc620a3bff7cdd7a365be3376c97191aeaccc2a603e600951e452615bf89"
+checksum = "db6d7e329c562c5dfab7a46a2afabc8b987ab9a4834c9d1ca04dc54c1546cef8"
 
 [[package]]
 name = "libsupervisionary"
@@ -201,10 +201,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2dffe52ecf27772e601905b7522cb4ef790d2cc203488bbd0e2fe85fcb74566d"
 
 [[package]]
+name = "memoffset"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5de893c32cde5f383baa4c04c5d6dbdd735cfd4a794b0debdb2bb1b421da5ff4"
+dependencies = [
+ "autocfg",
+]
+
+[[package]]
 name = "memory_units"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71d96e3f3c0b6325d8ccd83c33b28acb183edcb6c67938ba104ec546854b0882"
+
+[[package]]
+name = "nix"
+version = "0.26.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bfdda3d196821d6af13126e40375cdf7da646a96114af134d5f417a9a1dc8e1a"
+dependencies = [
+ "bitflags",
+ "cfg-if",
+ "libc",
+ "memoffset",
+ "pin-utils",
+ "static_assertions",
+]
 
 [[package]]
 name = "num-bigint"
@@ -261,6 +284,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "be5e13c266502aadf83426d87d81a0f5d1ef45b8027f5a471c360abfe4bfae92"
 
 [[package]]
+name = "pin-utils"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
 name = "regex"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -278,6 +307,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "456c603be3e8d448b072f410900c09faf164fbce2d480456f50eea6e25f9c848"
 
 [[package]]
+name = "static_assertions"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2eb9349b6444b326872e140eb1cf5e7c522154d69e7a0ffb0fb81c06b37543f"
+
+[[package]]
 name = "strsim"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -293,6 +328,10 @@ dependencies = [
 [[package]]
 name = "system-interface"
 version = "0.1.0"
+dependencies = [
+ "log",
+ "nix",
+]
 
 [[package]]
 name = "term"

--- a/libsupervisionary/src/raw/system.rs
+++ b/libsupervisionary/src/raw/system.rs
@@ -12,39 +12,15 @@
 //! [Dominic Mulligan]<https://dominicpm.github.io>
 
 use crate::raw::ErrorCode;
-use std::convert::TryFrom;
 
 extern "C" {
-    /// Raw ABI binding to the `System.IO.Write` function.
-    fn __system_io_write(bytes: *const u8, length: u64) -> i32;
-    /// Raw ABI binding to the `System.IO.WriteError` function.
-    fn __system_io_write_error(bytes: *const u8, length: u64) -> i32;
-}
-
-pub fn system_io_write<S>(s: S) -> Result<(), ErrorCode>
-where
-    S: Into<String>,
-{
-    let s = s.into();
-    let status = unsafe { __system_io_write(s.as_ptr(), s.len() as u64) };
-
-    if status == 0 {
-        Ok(())
-    } else {
-        Err(ErrorCode::try_from(status).unwrap())
-    }
-}
-
-pub fn system_io_write_error<S>(s: S) -> Result<(), ErrorCode>
-where
-    S: Into<String>,
-{
-    let s = s.into();
-    let status = unsafe { __system_io_write_error(s.as_ptr(), s.len() as u64) };
-
-    if status == 0 {
-        Ok(())
-    } else {
-        Err(ErrorCode::try_from(status).unwrap())
-    }
+    /// Raw ABI binding to the `System.IO.File.Open` function.
+    fn __system_io_fopen(
+        path: *const u8,
+        length: u32,
+        mode: u32,
+        handle: *mut u64,
+    ) -> i32;
+    /// Raw ABI binding to the `System.IO.File.Close` function.
+    fn __system_io_fclose(handle: u64) -> i32;
 }

--- a/system-interface/Cargo.toml
+++ b/system-interface/Cargo.toml
@@ -6,3 +6,5 @@ edition     = "2018"
 description = "A system interface for querying and manipulating the system."
 
 [dependencies]
+log = "0.4.17"
+nix = "0.26.2"

--- a/system-interface/src/lib.rs
+++ b/system-interface/src/lib.rs
@@ -1,3 +1,4 @@
+#![feature(cstr_from_bytes_until_nul)]
 //! # The Supervisionary system interface
 //!
 //! # Authors
@@ -11,7 +12,187 @@
 //!
 //! [Dominic Mulligan]<https://dominicpm.github.io>
 
+use std::convert::TryInto;
+
 pub mod pass_through;
+
+////////////////////////////////////////////////////////////////////////////////
+// File handles.
+////////////////////////////////////////////////////////////////////////////////
+
+/// The type of file handles, merely 64-bit machine words.
+pub type FileHandle = u64;
+
+/// The distinguished `stdout` file handle.
+pub const STDOUT_FILEHANDLE: FileHandle = 0;
+/// The distinguished `stdin` file handle.
+pub const STDIN_FILEHANDLE: FileHandle = 1;
+/// The distinguished `stderr` file handle.
+pub const STDERR_FILEHANDLE: FileHandle = 2;
+
+////////////////////////////////////////////////////////////////////////////////
+// File mode.
+////////////////////////////////////////////////////////////////////////////////
+
+/// File modes indicating whether a file should be opened as a readable,
+/// writeable or both, and so on.
+#[repr(u32)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum FileMode {
+    /// The file should be opened in a read-only mode.
+    Read = 0x0,
+    /// The file should be opened in a write-only mode.
+    Write = 0x1,
+    /// The file should be opened in a readable and writable mode.
+    ReadWrite = 0x2,
+    /// The file should be opened in an appendable mode.
+    Append = 0x3,
+}
+
+impl FileMode {
+    /// Converts a `FileMode` into a string encoding suitable for use with
+    /// `libc`-type functions that expect mode strings.
+    #[inline]
+    pub fn unix_file_mode(&self) -> &str {
+        match self {
+            FileMode::Read => "r",
+            FileMode::Write => "w",
+            FileMode::ReadWrite => "rw",
+            FileMode::Append => "a",
+        }
+    }
+}
+
+impl From<FileMode> for u32 {
+    #[inline]
+    fn from(value: FileMode) -> u32 {
+        match value {
+            FileMode::Read => 0x0,
+            FileMode::Write => 0x1,
+            FileMode::ReadWrite => 0x2,
+            FileMode::Append => 0x3,
+        }
+    }
+}
+
+impl TryInto<FileMode> for u32 {
+    type Error = ();
+
+    fn try_into(self) -> Result<FileMode, Self::Error> {
+        if self == 0x0 {
+            Ok(FileMode::Read)
+        } else if self == 0x1 {
+            Ok(FileMode::Write)
+        } else if self == 0x2 {
+            Ok(FileMode::ReadWrite)
+        } else if self == 0x3 {
+            Ok(FileMode::Append)
+        } else {
+            Err(())
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// File permissions.
+////////////////////////////////////////////////////////////////////////////////
+
+/// File permissions indicating whether a file handle points-to a file that is
+/// readable, writeable, or both.  Note we do not handle executable files (yet).
+#[repr(u32)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum FilePermissions {
+    /// The file read permission bit.
+    Read = 0x0,
+    /// The file write permission bit.
+    Write = 0x1,
+}
+
+impl From<FilePermissions> for u32 {
+    #[inline]
+    fn from(value: FilePermissions) -> u32 {
+        match value {
+            FilePermissions::Read => 0x0,
+            FilePermissions::Write => 0x1,
+        }
+    }
+}
+
+impl TryInto<FilePermissions> for u32 {
+    type Error = ();
+
+    fn try_into(self) -> Result<FilePermissions, Self::Error> {
+        if self == 0x0 {
+            Ok(FilePermissions::Read)
+        } else if self == 0x1 {
+            Ok(FilePermissions::Write)
+        } else {
+            Err(())
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// File types.
+////////////////////////////////////////////////////////////////////////////////
+
+/// File permissions indicating whether a file handle points-to a file that is
+/// readable, writeable, or both.  Note we do not handle executable files (yet).
+#[repr(u32)]
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum FileType {
+    /// A normal file, for example a text file inside the system's filesystem.
+    Normal = 0x0,
+    /// A special file, for example a file under kernel-management akin to the
+    /// Linux `/dev/` or `/proc/` filesystems.
+    Special = 0x1,
+}
+
+impl From<FileType> for u32 {
+    #[inline]
+    fn from(value: FileType) -> u32 {
+        match value {
+            FileType::Normal => 0x0,
+            FileType::Special => 0x1,
+        }
+    }
+}
+
+impl TryInto<FileType> for u32 {
+    type Error = ();
+
+    fn try_into(self) -> Result<FileType, Self::Error> {
+        if self == 0x0 {
+            Ok(FileType::Normal)
+        } else if self == 0x1 {
+            Ok(FileType::Special)
+        } else {
+            Err(())
+        }
+    }
+}
+
+////////////////////////////////////////////////////////////////////////////////
+// System interface error codes.
+////////////////////////////////////////////////////////////////////////////////
+
+/// System error codes, which indicate that something went wrong when trying to
+/// modify or query the system, and what.
+#[derive(Clone, Debug, Eq, Hash, Ord, PartialEq, PartialOrd)]
+pub enum SystemErrorCode {
+    /// A file or directory was unknown.
+    UnknownFile,
+    /// A filemode was invalid.
+    InvalidFileMode,
+    /// A file or directory had the wrong permissions.
+    PermissionError,
+    /// A file was not open, but somebody tried to close it.
+    FileNotOpen,
+    /// A path was not a valid UTF-8 filepath.
+    MalformedPath,
+    /// A file handle was not valid, and did not point-to an open file.
+    InvalidHandle,
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // The generic system interface trait.
@@ -23,9 +204,32 @@ pub mod pass_through;
 /// (e.g., the MacOS or Linux filesystem), or whether Supervisionary is
 /// maintaining its own synthetic, in-memory filesystem.
 pub trait SystemInterface {
-    /// Writes a string to `stdout` in the system interface.
-    fn write(&self, s: String);
+    /// Opens a file at a given path.  Note that the `path` is assumed to be
+    /// encoded as UTF-8 as a `/`-separated path.  If the path exists, the
+    /// function returns a file handle which can be used henceforth to refer to
+    /// the file.
+    fn fopen(
+        &mut self,
+        path: Vec<u8>,
+        mode: FileMode,
+    ) -> Result<FileHandle, SystemErrorCode>;
 
-    /// Writes a string to `stderr` in the system interface.
-    fn write_error(&self, s: String);
+    /// Closes a file pointed-to by a filehandle.
+    fn fclose(&mut self, handle: FileHandle) -> Result<(), SystemErrorCode>;
+
+    /// Writes a buffer of bytes to a file pointed-to by the filehandle.
+    fn fwrite(
+        &mut self,
+        handle: FileHandle,
+        buffer: Vec<u8>,
+        count: usize,
+    ) -> Result<usize, SystemErrorCode>;
+
+    /// Reads a buffer of bytes from a file pointed-to by the filehandle.
+    fn fread(
+        &mut self,
+        handle: FileHandle,
+        buffer: &mut [u8],
+        count: usize,
+    ) -> Result<usize, SystemErrorCode>;
 }

--- a/tests/system/src/main.rs
+++ b/tests/system/src/main.rs
@@ -14,9 +14,5 @@
 use libsupervisionary::raw::{system::*, ErrorCode};
 
 fn main() -> Result<(), ErrorCode> {
-    system_io_write("Hello, world!")?;
-
-    system_io_write_error("Error!  Error!")?;
-
     Ok(())
 }

--- a/tests/theorem/src/main.rs
+++ b/tests/theorem/src/main.rs
@@ -11,12 +11,12 @@
 //!
 //! [Dominic Mulligan]: https://dominicpm.github.io
 
-use libsupervisionary::raw::{system::system_io_write, theorem::*, ErrorCode};
+use libsupervisionary::raw::{theorem::*, ErrorCode};
 
 fn main() -> Result<(), ErrorCode> {
-    system_io_write(format!(
-        "PREALLOCATED_HANDLE_THEOREM_TRUTH_INTRODUCTION: {PREALLOCATED_HANDLE_THEOREM_TRUTH_INTRODUCTION:?}\n",
-    ))?;
+    assert!(theorem_is_registered(
+        PREALLOCATED_HANDLE_THEOREM_TRUTH_INTRODUCTION
+    ));
 
     Ok(())
 }

--- a/wasmi-bindings/src/system_call_numbers.rs
+++ b/wasmi-bindings/src/system_call_numbers.rs
@@ -511,13 +511,20 @@ pub(crate) const ABI_THEOREM_SPLIT_CONCLUSION_INDEX: usize = 92;
 // System access system calls.
 ////////////////////////////////////////////////////////////////////////////////
 
-/// The name of the `System.IO.Write` ABI call.
-pub(crate) const ABI_SYSTEM_IO_WRITE_NAME: &str = "__system_io_write";
-/// The name of the `System.IO.WriteError` ABI call.
-pub(crate) const ABI_SYSTEM_IO_WRITE_ERROR_NAME: &str =
-    "__system_io_write_error";
+/// The name of the `System.IO.File.Open` ABI call.
+pub(crate) const ABI_SYSTEM_IO_FOPEN_NAME: &str = "__system_io_fopen";
+/// The name of the `System.IO.File.Close` ABI call.
+pub(crate) const ABI_SYSTEM_IO_FCLOSE_NAME: &str = "__system_io_fclose";
+/// The name of the `System.IO.File.Read` ABI call.
+pub(crate) const ABI_SYSTEM_IO_FREAD_NAME: &str = "__system_io_fread";
+/// The name of the `System.IO.File.Write` ABI call.
+pub(crate) const ABI_SYSTEM_IO_FWRITE_NAME: &str = "__system_io_fwrite";
 
-/// The index of the `System.IO.Write` ABI call.
-pub(crate) const ABI_SYSTEM_IO_WRITE_INDEX: usize = 93;
-/// The index of the `System.IO.WriteError` ABI call.
-pub(crate) const ABI_SYSTEM_IO_WRITE_ERROR_INDEX: usize = 94;
+/// The index of the `System.IO.File.Open` ABI call.
+pub(crate) const ABI_SYSTEM_IO_FOPEN_INDEX: usize = 93;
+/// The index of the `System.IO.File.Close` ABI call.
+pub(crate) const ABI_SYSTEM_IO_FCLOSE_INDEX: usize = 94;
+/// The index of the `System.IO.File.Read` ABI call.
+pub(crate) const ABI_SYSTEM_IO_FREAD_INDEX: usize = 95;
+/// The index of the `System.IO.File.Write` ABI call.
+pub(crate) const ABI_SYSTEM_IO_FWRITE_INDEX: usize = 96;

--- a/wasmi-bindings/src/system_interface_types.rs
+++ b/wasmi-bindings/src/system_interface_types.rs
@@ -37,6 +37,10 @@ pub(crate) mod semantic_types {
     /// reading-from and writing-to the guest WASM program heap, assuming the
     /// `wasm32-abi`.
     pub type Size = u64;
+    /// A file mode, used for specifying how a file should be opened by `fopen`.
+    pub type FileMode = u32;
+    /// A filehandle.
+    pub type FileHandle = u64;
 }
 
 /// A type capturing semantic types of the ABI, more descriptive than the base
@@ -49,6 +53,10 @@ pub(crate) enum AbiType {
     Name,
     /// An arity for a type-former.
     Arity,
+    /// A file-mode.
+    FileMode,
+    /// A filehandle.
+    FileHandle,
     /// A pointer into the host WASM program's heap.
     Pointer,
     /// A size (or length) of an object appearing in the WASM program's heap.
@@ -71,6 +79,8 @@ impl AbiType {
             AbiType::Pointer => tau == &ValueType::I32,
             AbiType::Size => tau == &ValueType::I64,
             AbiType::ErrorCode => tau == &ValueType::I32,
+            AbiType::FileMode => tau == &ValueType::I32,
+            AbiType::FileHandle => tau == &ValueType::I64,
         }
     }
 }

--- a/wasmi-bindings/src/type_checking.rs
+++ b/wasmi-bindings/src/type_checking.rs
@@ -1202,24 +1202,59 @@ pub(crate) fn check_theorem_size_signature(signature: &Signature) -> bool {
 // Type-checking system access system calls.
 ////////////////////////////////////////////////////////////////////////////////
 
-/// Checks the signature of the `System.IO.Write` ABI function.
+/// Checks the signature of the `System.IO.File.Open` ABI function.
 #[inline]
-pub(crate) fn check_system_io_write_signature(signature: &Signature) -> bool {
+pub(crate) fn check_system_io_fopen_signature(signature: &Signature) -> bool {
     check_signature(
         signature,
-        &[AbiType::Pointer, AbiType::Size],
+        &[
+            AbiType::Pointer,
+            AbiType::Size,
+            AbiType::FileMode,
+            AbiType::Pointer,
+        ],
         &Some(AbiType::ErrorCode),
     )
 }
 
-/// Checks the signature of the `System.IO.WriteError` ABI function.
+/// Checks the signature of the `System.IO.File.Close` ABI function.
 #[inline]
-pub(crate) fn check_system_io_write_error_signature(
-    signature: &Signature,
-) -> bool {
+pub(crate) fn check_system_io_fclose_signature(signature: &Signature) -> bool {
     check_signature(
         signature,
-        &[AbiType::Pointer, AbiType::Size],
+        &[AbiType::FileHandle],
+        &Some(AbiType::ErrorCode),
+    )
+}
+
+/// Checks the signature of the `System.IO.File.Write` ABI function.
+#[inline]
+pub(crate) fn check_system_io_fwrite_signature(signature: &Signature) -> bool {
+    check_signature(
+        signature,
+        &[
+            AbiType::FileHandle,
+            AbiType::Pointer,
+            AbiType::Size,
+            AbiType::Size,
+            AbiType::Pointer,
+        ],
+        &Some(AbiType::ErrorCode),
+    )
+}
+
+/// Checks the signature of the `System.IO.File.Read` ABI function.
+#[inline]
+pub(crate) fn check_system_io_fread_signature(signature: &Signature) -> bool {
+    check_signature(
+        signature,
+        &[
+            AbiType::FileHandle,
+            AbiType::Pointer,
+            AbiType::Size,
+            AbiType::Size,
+            AbiType::Pointer,
+        ],
         &Some(AbiType::ErrorCode),
     )
 }


### PR DESCRIPTION
Reworked Supervisionary system interface.  Added:
  - fopen and fclose: for opening and closing filehandles,
  - fread and fwrite: for reading and writing from a filehandle.

Added distinguished file handles: stdout, stdin, and stderr, with I/O on these filehandles just using the functions above.

More to come...

Signed-off-by: Dominic Mulligan <dominic.p.mulligan@gmail.com>