### PR TITLE
libsupervisionary: added System.IO bindings to libsupervisionary

### DIFF
--- a/libsupervisionary/src/raw/system.rs
+++ b/libsupervisionary/src/raw/system.rs
@@ -23,4 +23,20 @@ extern "C" {
     ) -> i32;
     /// Raw ABI binding to the `System.IO.File.Close` function.
     fn __system_io_fclose(handle: u64) -> i32;
+    /// Raw ABI binding to the `System.IO.File.Write` function.
+    fn __system_io_fwrite(
+        handle: u64,
+        buffer: *const u8,
+        length: u32,
+        count: u32,
+        written: *mut u32,
+    ) -> i32;
+    /// Raw ABI binding to the `System.IO.File.Read` function.
+    fn __system_io_fread(
+        handle: u64,
+        buffer: *mut u8,
+        length: u32,
+        count: u32,
+        written: *mut u32,
+    ) -> i32;
 }


### PR DESCRIPTION
Signed-off-by: Dominic Mulligan <dominic.p.mulligan@gmail.com>